### PR TITLE
Use usePrevious hook to let user go back to preferences form

### DIFF
--- a/src/components/Preferences/Preferences.jsx
+++ b/src/components/Preferences/Preferences.jsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Link, useHistory } from 'react-router-dom';
 import { Container, Segment } from 'semantic-ui-react';
 import { getUser, updateUser } from '@plone/volto/actions';
+import { usePrevious } from '@plone/volto/helpers';
 import { Form, Icon, Toast } from '@plone/volto/components';
 import { Plug } from '@plone/volto/components/manage/Pluggable';
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
@@ -51,8 +52,9 @@ function Preferences({ closeMenu, toastify }) {
     dispatch(getUser(userId));
   }, [dispatch, userId]);
 
+  const prevUpdating = usePrevious(updating);
   useEffect(() => {
-    if (updated) {
+    if (prevUpdating && updated) {
       toast.success(
         <Toast
           success
@@ -64,7 +66,7 @@ function Preferences({ closeMenu, toastify }) {
       else history.goBack();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [updated]);
+  }, [prevUpdating, updated]);
 
   function onChangeFormData(data) {
     setEnabled(!!data.two_factor_authentication_enabled);


### PR DESCRIPTION
Fixes bug with preferences form. If you have already saved the form you cannot re-open it because the value of `updated` will be true. This PR uses `usePrevious` helper to ensure the form closing only fires when a it has been saved.
