### PR TITLE
Add site title as issuer to otpauth uri

### DIFF
--- a/src/components/Preferences/QRCodeWidget.jsx
+++ b/src/components/Preferences/QRCodeWidget.jsx
@@ -21,6 +21,9 @@ export const QRCodeWidget = ({
     state.userSession.token ? jwtDecode(state.userSession.token).sub : '',
   );
   const [secret, setSecret] = useState();
+  const site_title = useSelector((state) =>
+    state.site.data['plone.site_title']
+  );
 
   useEffect(() => {
     const secret = encode(Math.random().toString(36))
@@ -43,7 +46,7 @@ export const QRCodeWidget = ({
         */}
           <QRCodeSVG
             size={200}
-            value={`otpauth://totp/${userId}@${window.location.hostname}?secret=${secret}`}
+            value={`otpauth://totp/${userId}@${window.location.hostname}?secret=${secret}&issuer=${site_title}`}
           />
           <input
             type="hidden"


### PR DESCRIPTION
This PR adds the title of the site as the issuer parameter when generating the otpauth uri.

This is useful for apps which use this value to add a logo.

e.g. from https://support.authy.com/hc/en-us/articles/360002908333-Adding-custom-logos-in-the-Authy-app

> As the vendor of an application, how can I change the logo associated with my application’s account token?
>
>There are two different scenarios with different solutions. If you are using the Authy API to generate your Authy account token, then you can change the logo in [Twilio Console](https://www.twilio.com/console). If you are not using the Authy API, then the Authy app uses Google Image Search API to find a logo, using your Google Authenticator token’s Issuer name as the default search term. The user can also try other search terms to find a better logo. The search results may not be perfect 100% of the time, because Google Image Search isn’t perfect. If you recently changed your application’s logo, it may take some time for Google to figure out that that is the most relevant logo for your application’s name. In general, we will not change your application’s logo to something different than what is returned by Google.